### PR TITLE
Chunkloader duration lowered & automation enabled

### DIFF
--- a/config/immibis.cfg
+++ b/config/immibis.cfg
@@ -10,12 +10,12 @@ chunkloader {
 
 general {
     B:autoAssign=false
-    B:chunkloader.allowFuelPiping=false
+    B:chunkloader.allowFuelPiping=true
     B:chunkloader.bypassForgeChunkLimits=true
     B:chunkloader.enableCrafting=true
 
     # comma-separated list of mod:item-name@meta=number-of-ticks or mod:item-name=number-of-ticks
-    S:chunkloader.fuels=minecraft:ender_pearl=4320000
+    S:chunkloader.fuels=minecraft:ender_pearl=2400
     B:chunkloader.hideOtherPlayersLoadersInF9=false
 
     # Maximum number of chunks loaded by each player. Use -2 for unlimited.


### PR DESCRIPTION
Changed chunkloader fuel duration from 6+ hours to 2 minutes, and allowed for fuel automation. Chunkloaders will now require an ongoing source of enderpeals to use, but can be automated.
(Numbers are for a 3x3 chunk area. A single chunk loads for 60 hours with one enderpearl on current settings)
