### PR TITLE
Oredict shards -> Thaumcraft originals

### DIFF
--- a/scripts/main.zs
+++ b/scripts/main.zs
@@ -786,3 +786,13 @@ mods.agricraft.SeedMutation.remove(<AgriCraft:seedPetinia>);
 mods.agricraft.SeedMutation.remove(<AgriCraft:seedPlombean>);
 mods.agricraft.SeedMutation.remove(<AgriCraft:seedPlatiolus>);
 mods.agricraft.SeedMutation.remove(<AgriCraft:seedOsmonium>);
+
+// Thaumcraft - minor workaround to convert any shard to it's thaumcraft specific type
+recipes.addShapless(<Thaumcraft:ItemShard:0>, [<ore:shardAir>];
+recipes.addShapless(<Thaumcraft:ItemShard:1>, [<ore:shardFire>];
+recipes.addShapless(<Thaumcraft:ItemShard:2>, [<ore:shardWater>];
+recipes.addShapless(<Thaumcraft:ItemShard:3>, [<ore:shardEarth>];
+recipes.addShapless(<Thaumcraft:ItemShard:4>, [<ore:shardOrder>];
+recipes.addShapless(<Thaumcraft:ItemShard:5>, [<ore:shardEntropy>];
+
+


### PR DESCRIPTION
Added minetweaker script for converting each oredict shard entry back to it's thaumcraft original shard, as a quick work around for gregtech messing things up.
