### PR TITLE
Alt method to get Mobis Stable Ingots (ExtraUtilities)

### DIFF
--- a/scripts/main.zs
+++ b/scripts/main.zs
@@ -786,3 +786,7 @@ mods.agricraft.SeedMutation.remove(<AgriCraft:seedPetinia>);
 mods.agricraft.SeedMutation.remove(<AgriCraft:seedPlombean>);
 mods.agricraft.SeedMutation.remove(<AgriCraft:seedPlatiolus>);
 mods.agricraft.SeedMutation.remove(<AgriCraft:seedOsmonium>);
+
+// Alt method to get mobis stable ingots for extra utilities 
+recipes.addShaped(<ExtraUtilities:unstableingot:2>,[[null, <ExtraUtilities:unstableingot:1>,null],[<ExtraUtilities:unstableingot:1>,<minecraft:nether_star>,<ExtraUtilities:unstableingot:1>],[null,<ExtraUtilities:unstableingot:1>,null]]);
+ 


### PR DESCRIPTION
Uses 4 stable nuggets and a nether star
(Required as the original method remains bugged and does not work)
