### PR TITLE
RFTools quarry balance

### DIFF
--- a/config/rftools/main.cfg
+++ b/config/rftools/main.cfg
@@ -1414,7 +1414,7 @@ spaceprojector {
     I:builderRfPerPlayer=40000
 
     # Base RF per block operation for the builder when used as a quarry or voider (actual cost depends on hardness of block)
-    I:builderRfPerQuarry=300
+    I:builderRfPerQuarry=3000
     I:chamberControllerMaxRF=100000
     I:chamberControllerRFPerTick=1000
 

--- a/scripts/main.zs
+++ b/scripts/main.zs
@@ -96,6 +96,12 @@ recipes.addShaped(<rftools:machineFrame:0>, [
 recipes.remove(<rftools:machineBase:0>);
 recipes.addShapeless(<rftools:machineBase:0> * 4, [<rftools:machineFrame:0>]);
 
+// RFTools - Require that building a quarry shape for builder takes a buildcraft quarry to do
+recipes.remove(<rftools:shapeCardItem:2>);
+recipes.addShaped(<rftools:shapeCardItem:2>, [[<BuildCraft|Core:markerBlock>,<minecraft:redstone>,<BuildCraft|Core:markerBlock>],[<minecraft:redstone>,<BuildCraft|Builders:machineBlock:0>,<minecraft:redstone>],[<BuildCraft|Core:markerBlock>,<minecraft:redstone>,<BuildCraft|Core:markerBlock>]]);
+recipes.addShaped(<rftools:shapeCardItem:2>, [[<minecraft:dirt>,<minecraft:dirt>,<minecraft:dirt>],[<minecraft:dirt>,<rftools:shapeCardItem:5>,<minecraft:dirt>],[<minecraft:dirt>,<minecraft:dirt>,<minecraft:dirt>]]);
+
+
 // ExU
 recipes.remove(<ExtraUtilities:enderQuarry>);
 recipes.addShaped(<ExtraUtilities:enderQuarry>, [


### PR DESCRIPTION
Energy cost for the builder increased 10x

Recipe for the builder module now requires a buildcraft quarry to make (alongside 4 markers and 4 redstone)
